### PR TITLE
don’t overwrite collection to fix require updates

### DIFF
--- a/test/__tests__/upgrade-requires-1.0.js
+++ b/test/__tests__/upgrade-requires-1.0.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+describe('Migrate imports from react-relay to react-relay/classic', () => {
+  it('transforms correctly', () => {
+    test('upgrade-requires-1.0', 'requires/SimpleRequire');
+    test('upgrade-requires-1.0', 'requires/SimpleImport');
+  });
+});

--- a/test/requires/SimpleImport.js
+++ b/test/requires/SimpleImport.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+import Child from './child';
+import Relay from 'react-relay';
+
+class TestComponent extends React.Component {
+  render() {
+    return (
+      <span>
+        <Child data={this.props.foo} />
+      </span>
+    );
+  }
+}
+
+export default Relay.createContainer(TestComponent, {
+  fragments: {
+    foo: () => Relay.QL`
+      fragment on Foo {
+        ${Child.getFragment('foo')},
+        bar,
+        baz
+      }
+    `,
+  },
+});

--- a/test/requires/SimpleImport.output.js
+++ b/test/requires/SimpleImport.output.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+import Child from './child';
+import Relay from 'react-relay/classic';
+
+class TestComponent extends React.Component {
+  render() {
+    return (
+      <span>
+        <Child data={this.props.foo} />
+      </span>
+    );
+  }
+}
+
+export default Relay.createContainer(TestComponent, {
+  fragments: {
+    foo: () => Relay.QL`
+      fragment on Foo {
+        ${Child.getFragment('foo')},
+        bar,
+        baz
+      }
+    `,
+  },
+});

--- a/test/requires/SimpleRequire.js
+++ b/test/requires/SimpleRequire.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var Child = require('./child');
+var Relay = require('react-relay');
+
+class TestComponent extends React.Component {
+  render() {
+    return (
+      <span>
+        <Child data={this.props.foo} />
+      </span>
+    );
+  }
+}
+
+export default Relay.createContainer(TestComponent, {
+  fragments: {
+    foo: () => Relay.QL`
+      fragment on Foo {
+        ${Child.getFragment('foo')},
+        bar,
+        baz
+      }
+    `,
+  },
+});

--- a/test/requires/SimpleRequire.output.js
+++ b/test/requires/SimpleRequire.output.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var Child = require('./child');
+var Relay = require('react-relay/classic');
+
+class TestComponent extends React.Component {
+  render() {
+    return (
+      <span>
+        <Child data={this.props.foo} />
+      </span>
+    );
+  }
+}
+
+export default Relay.createContainer(TestComponent, {
+  fragments: {
+    foo: () => Relay.QL`
+      fragment on Foo {
+        ${Child.getFragment('foo')},
+        bar,
+        baz
+      }
+    `,
+  },
+});

--- a/transforms/upgrade-requires-1.0.js
+++ b/transforms/upgrade-requires-1.0.js
@@ -11,11 +11,11 @@
 
 module.exports = function(file, api, options) {
   const j = api.jscodeshift;
-  let collection = j(file.source);
+  const collection = j(file.source);
   const printOptions =
     options.printOptions || {quote: 'single', trailingComma: true};
 
-  collection = collection
+  collection
     .find(j.ImportDeclaration)
     .filter(path => path.value.source.value === 'react-relay')
     .forEach(path => {


### PR DESCRIPTION
This codemod currently only updates `import` statements. After the first pass to replace `import`'s the collection array is replaced with one that is filtered to only contain `imports`, so it will never find the `require` statements.